### PR TITLE
feat(coasy): add sendPushNotification action

### DIFF
--- a/packages/pieces/community/coasy/package.json
+++ b/packages/pieces/community/coasy/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@coasy/piece-coasy",
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/packages/pieces/community/coasy/package.json
+++ b/packages/pieces/community/coasy/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@coasy/piece-coasy",
-  "version": "0.2.1"
+  "version": "0.2.3"
 }

--- a/packages/pieces/community/coasy/src/index.ts
+++ b/packages/pieces/community/coasy/src/index.ts
@@ -8,6 +8,7 @@ import { createFunnelParticipant } from './lib/actions/create-funnel-participant
 import { createVoucher } from './lib/actions/create-voucher';
 import { enrollUserCourse } from './lib/actions/enroll-user-course';
 import { findEvent } from './lib/actions/find-event';
+import { sendPushNotification } from './lib/actions/send-push-notification';
 import { cancelledMembership } from './lib/triggers/cancelled-membership';
 import { cancelledOrder } from './lib/triggers/cancelled-order';
 import { cancelledOrderItem } from './lib/triggers/cancelled-order-item';
@@ -57,6 +58,7 @@ export const coasy = createPiece({
     createVoucher,
     enrollUserCourse,
     findEvent,
+    sendPushNotification,
   ],
   triggers: [
     cancelledMembership,

--- a/packages/pieces/community/coasy/src/lib/actions/send-push-notification.ts
+++ b/packages/pieces/community/coasy/src/lib/actions/send-push-notification.ts
@@ -1,0 +1,65 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { coasyAuth } from '../../index';
+import { runCoasyAction } from '../common/actions';
+
+const name = 'sendPushNotification';
+
+export const sendPushNotification = createAction({
+  auth: coasyAuth,
+  name,
+  displayName: 'Send Push Notification',
+  description: 'Queues a push notification to all active devices of a user',
+  props: {
+    userId: Property.ShortText({
+      displayName: 'User ID',
+      description: 'Coasy user ID to deliver the notification to',
+      required: true,
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      description: 'Notification title shown on the device',
+      required: true,
+    }),
+    body: Property.LongText({
+      displayName: 'Body',
+      description: 'Notification body text shown on the device',
+      required: true,
+    }),
+    topic: Property.StaticDropdown({
+      displayName: 'Topic',
+      description: 'Optional topic tag for categorising the notification',
+      required: false,
+      options: {
+        options: [
+          { label: 'Community', value: 'COMMUNITY' },
+          { label: 'Chat', value: 'CHAT' },
+          { label: 'Friendship', value: 'FRIENDSHIP' },
+          { label: 'Challenge', value: 'CHALLENGE' },
+          { label: 'Event', value: 'EVENT' },
+          { label: 'Meditations', value: 'MEDITATIONS' },
+        ],
+      },
+    }),
+    url: Property.ShortText({
+      displayName: 'URL',
+      description: 'Optional deep link opened when the notification is tapped',
+      required: false,
+    }),
+    threadId: Property.ShortText({
+      displayName: 'Thread ID',
+      description: 'Optional thread identifier for grouping notifications on iOS',
+      required: false,
+    }),
+    data: Property.Object({
+      displayName: 'Data',
+      description: 'Optional custom payload forwarded to the app',
+      required: false,
+    }),
+    delay: Property.Number({
+      displayName: 'Delay (seconds)',
+      description: 'Optional delay in seconds before the notification is sent',
+      required: false,
+    }),
+  },
+  run: (configValue) => runCoasyAction(configValue, name),
+});


### PR DESCRIPTION
## Summary

Adds a new `sendPushNotification` action to the Coasy piece. It calls `POST /apps/actions/sendPushNotification` on the Coasy Backend API, which queues a push notification to every active device of the given user.

## Changes

- New: `src/lib/actions/send-push-notification.ts`
- `src/index.ts`: import + register action
- `package.json`: `0.2.0` → `0.2.1`

## Action props

- `userId` (required) — Coasy user ID
- `title` (required) — notification title
- `body` (required, long text) — notification body
- `topic` (optional, dropdown) — one of COMMUNITY, CHAT, FRIENDSHIP, CHALLENGE, EVENT, MEDITATIONS
- `url`, `threadId`, `data`, `delay` (optional)

## Depends on

- csyt-backend-api PR #40 that exposes `POST /apps/actions/sendPushNotification`

## Test plan

- [x] `nx build pieces-coasy` passes locally
- [ ] Publish `@coasy/piece-coasy@0.2.1` once backend is live
- [ ] In an ActivePieces flow: send a push to a test user and confirm delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)