### PR TITLE
feat: add Funnel Guard to addTrialPeriod action

### DIFF
--- a/packages/pieces/community/coasy/CLAUDE.md
+++ b/packages/pieces/community/coasy/CLAUDE.md
@@ -35,5 +35,6 @@ The doc is **private** — fetch it with `gh api repos/coasy/coasy-core/contents
 - **`createFunnelParticipant`** lowercases `email` server-side. The response includes server-generated `funnelParticipantId`, `registrationTime`, and `timestamp`.
 - **`createVoucher`** auto-generates the voucher ID (`VOC-…`) and sets `status: "ACTIVE"`. Setting `countLeft` implicitly sets `isCountLimited: true`.
 - **`addTrialPeriod`** has its own domain error model (`AppSubscriptionError`) mapped to HTTP via `toApiErrorIfAppSubscriptionError` — surface the server's error message rather than masking it.
+- **`addTrialPeriod` funnel guard** (coasy-core PR #220): the piece's `funnelGuard` array maps to the nested body `guards: { funnel: string[] }`. Guards are checked before the user is resolved; a match is a **silent no-op success** (`subscriptionStatus: "BLOCKED"`, `blockedBy` set, HTTP 200) — nothing is created/extended. Omitting it preserves original behavior.
 
 When the upstream doc changes, refresh this file by re-fetching the source via `gh api`.

--- a/packages/pieces/community/coasy/package.json
+++ b/packages/pieces/community/coasy/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@coasy/piece-coasy",
-  "version": "0.2.4"
+  "version": "0.2.5"
 }

--- a/packages/pieces/community/coasy/src/lib/actions/add-trial-period.ts
+++ b/packages/pieces/community/coasy/src/lib/actions/add-trial-period.ts
@@ -4,6 +4,31 @@ import { runCoasyAction } from '../common/actions';
 
 const name = 'addTrialPeriod';
 
+// Reshapes flat guard props into the nested `guards: { ... }` body the server
+// expects. `guardSources` maps a prop name to its server guard key (e.g.
+// `{ funnelGuard: 'funnel' }`). Blank entries are dropped and `guards` is omitted
+// when no guard has any value.
+const buildGuardedRequest = (
+  request: Record<string, unknown>,
+  guardSources: Record<string, string>
+): Record<string, unknown> => {
+  const rest = { ...request };
+  const guards: Record<string, unknown> = {};
+
+  for (const [propName, guardKey] of Object.entries(guardSources)) {
+    const value = rest[propName];
+    delete rest[propName];
+    const ids = Array.isArray(value)
+      ? value.filter((id) => typeof id === 'string' && id.trim() !== '')
+      : [];
+    if (ids.length > 0) {
+      guards[guardKey] = ids;
+    }
+  }
+
+  return Object.keys(guards).length > 0 ? { ...rest, guards } : rest;
+};
+
 export const addTrialPeriod = createAction({
   auth: coasyAuth,
   name,
@@ -37,6 +62,17 @@ export const addTrialPeriod = createAction({
       description: 'Optional first name, forwarded when a new user is created.',
       required: false,
     }),
+    funnelGuard: Property.Array({
+      displayName: 'Funnel Guard',
+      description:
+        'Guards against extending the trial period if the user is already a funnel participant in one of these funnels.',
+      required: false,
+    }),
   },
-  run: (configValue) => runCoasyAction(configValue, name),
+  run: (configValue) =>
+    runCoasyAction(
+      configValue,
+      name,
+      buildGuardedRequest(configValue.propsValue, { funnelGuard: 'funnel' })
+    ),
 });

--- a/packages/pieces/community/coasy/src/lib/common/actions.ts
+++ b/packages/pieces/community/coasy/src/lib/common/actions.ts
@@ -7,7 +7,8 @@ import { CoasyClient } from './coasyClient';
 
 export const runCoasyAction = async <T extends InputPropertyMap>(
   configValue: ActionContext<typeof coasyAuth, T>,
-  action: string
+  action: string,
+  request?: Record<string, unknown>
 ) => {
   const { propsValue, auth: authPayload } = configValue;
   const client = new CoasyClient(
@@ -15,10 +16,8 @@ export const runCoasyAction = async <T extends InputPropertyMap>(
     authPayload.apiKey
   );
 
-  const { ...restPropsValue } = propsValue;
+  const body = { ...(request ?? propsValue) };
+  delete body['auth'];
 
-  delete restPropsValue['auth'];
-
-  const request = { ...restPropsValue };
-  return client.action(action, request);
+  return client.action(action, body);
 };


### PR DESCRIPTION
## What

Adds an optional **Funnel Guard** field to the `addTrialPeriod` action.

When set, it guards against granting/extending a trial if the user is already a participant of one of the listed funnels — mapping to the server's nested `guards: { funnel: [...] }` body introduced in [coasy-core PR #220](https://github.com/coasy/coasy-core/pull/220).

## How

- New optional `funnelGuard` `Property.Array` prop (displayName **Funnel Guard**).
- A local `buildGuardedRequest` helper reshapes the flat prop into `guards: { funnel: [...] }`, dropping blank entries and omitting `guards` entirely when empty — so the request is unchanged from 0.2.4 when the field is unused.
- `runCoasyAction` gains an optional `request` override so the helper output can be passed through without duplicating the client/auth setup. All other actions call it the same way as before and are unaffected.

## Behavior

Per PR #220: a matched guard is a **silent no-op success** (`subscriptionStatus: "BLOCKED"`, `blockedBy` set, HTTP 200) — nothing is created or extended. Omitting the field preserves the original behavior.

## Release

- Bumps `@coasy/piece-coasy` to **0.2.5** and published to npm.
- Manually tested against the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215599588130227