### PR TITLE
feat(coasy): add removeFromUser action

### DIFF
--- a/packages/pieces/community/coasy/CLAUDE.md
+++ b/packages/pieces/community/coasy/CLAUDE.md
@@ -15,7 +15,7 @@ The doc is **private** — fetch it with `gh api repos/coasy/coasy-core/contents
 - **Validation:** Server-side via `class-validator`. Bad bodies return `400` with field details.
 - **Response shape:** `{ "message": "...", "<entity>": { ... } }`
 
-### Available actions (as of 2026-05-06)
+### Available actions (as of 2026-07-08)
 
 | Action | Endpoint | Purpose |
 | --- | --- | --- |
@@ -26,11 +26,13 @@ The doc is **private** — fetch it with `gh api repos/coasy/coasy-core/contents
 | `createVoucher` | `POST /apps/actions/createVoucher` | Create a discount voucher tied to offers |
 | `enrollUserCourse` | `POST /apps/actions/enrollUserCourse` | Enroll a user in a course |
 | `findEvent` | `POST /apps/actions/findEvent` | Find events of the calling app by exact title |
+| `removeFromUser` | `POST /apps/actions/removeFromUser` | Remove features / community topics / topic groups / meditation categories from a user |
 | `sendPushNotification` | `POST /apps/actions/sendPushNotification` | Send a push notification to all of a user's devices |
 
 ### Gotchas worth remembering
 
-- **`assignToUser`** requires at least one of `features` / `communityTopics` / `communityTopicGroups` / `meditationCategories`; otherwise the server returns `400`. Cross-app `userId` returns `401`, not `404`.
+- **`assignToUser`** requires at least one of `features` / `communityTopics` / `communityTopicGroups` / `meditationCategories`; otherwise the server returns `400`. Cross-app `userId` returns `401`, not `404`. It **does** validate that every referenced entity exists (`404` if not) — `removeFromUser` deliberately does not.
+- **`removeFromUser`** (coasy-core PR #452) is the idempotent counterpart to `assignToUser`, same four array fields. Removing a value the user does not have is a **success**, not an error: HTTP `200`, `message: "Nothing to remove for user."`, `removed: {}`, and no write to the user record. Referenced entities are **not** existence-checked, so a deleted feature or meditation category stays removable. Same guards as `assignToUser` otherwise: unknown `userId` → `404`, cross-app `userId` → `401`, no field provided → `400`. The response adds a `removed` map reporting which values were actually present. Note the server rejects unknown body fields (`courses` is **not** supported here — courses use `enrollUserCourse`).
 - **`sendPushNotification`** accepts a `topic` field in the DTO but it is silently discarded by the current `buildNotification` implementation — do not expose it as a piece property until the upstream handler is fixed.
 - **`createFunnelParticipant`** lowercases `email` server-side. The response includes server-generated `funnelParticipantId`, `registrationTime`, and `timestamp`.
 - **`createVoucher`** auto-generates the voucher ID (`VOC-…`) and sets `status: "ACTIVE"`. Setting `countLeft` implicitly sets `isCountLimited: true`.

--- a/packages/pieces/community/coasy/package.json
+++ b/packages/pieces/community/coasy/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@coasy/piece-coasy",
-  "version": "0.2.5"
+  "version": "0.2.6"
 }

--- a/packages/pieces/community/coasy/src/index.ts
+++ b/packages/pieces/community/coasy/src/index.ts
@@ -26,6 +26,7 @@ import { webinarParticipantAttend } from './lib/triggers/webinar-participant-att
 import { webinarParticipantReminder } from './lib/triggers/webinar-participant-reminder';
 import { addTrialPeriod } from './lib/actions/add-trial-period';
 import { assignToUser } from './lib/actions/assign-to-user';
+import { removeFromUser } from './lib/actions/remove-from-user';
 
 export const coasyAuth = PieceAuth.CustomAuth({
   required: true,
@@ -60,6 +61,7 @@ export const coasy = createPiece({
     createVoucher,
     enrollUserCourse,
     findEvent,
+    removeFromUser,
     sendPushNotification,
   ],
   triggers: [

--- a/packages/pieces/community/coasy/src/lib/actions/remove-from-user.ts
+++ b/packages/pieces/community/coasy/src/lib/actions/remove-from-user.ts
@@ -1,0 +1,42 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { coasyAuth } from '../..';
+import { runCoasyAction } from '../common/actions';
+
+const name = 'removeFromUser';
+
+export const removeFromUser = createAction({
+  auth: coasyAuth,
+  name,
+  displayName: 'Remove From User',
+  description:
+    'Removes features, community topics, community topic groups, or meditation categories from a user. Values the user does not have are ignored without raising an error',
+  props: {
+    userId: Property.ShortText({
+      displayName: 'User ID',
+      description: 'ID of User',
+      required: true,
+    }),
+    features: Property.Array({
+      displayName: 'Features',
+      description: 'List of feature IDs to remove',
+      required: false,
+    }),
+    communityTopics: Property.Array({
+      displayName: 'Community Topics',
+      description: 'List of community topic IDs to remove',
+      required: false,
+    }),
+    communityTopicGroups: Property.Array({
+      displayName: 'Community Topic Groups',
+      description: 'List of community topic group IDs to remove',
+      required: false,
+    }),
+    meditationCategories: Property.Array({
+      displayName: 'Meditation Categories',
+      description:
+        'List of meditation category IDs to remove. The format is "libraryId/categoryId"',
+      required: false,
+    }),
+  },
+  run: (configValue) => runCoasyAction(configValue, name),
+});


### PR DESCRIPTION
## Was

Counterpart to `Coasy (Assign To User)`. Flows could grant features, community topics, community topic groups and meditation categories to a user — but never take them away. This adds `Coasy (Remove From User)`, same four array fields.

Backed by **coasy-core PR #452** (`POST /apps/actions/removeFromUser`).

## Idempotent by design

Removing a value the user does not have is a **success, not an error**:

- HTTP `200`, `message: "Nothing to remove for user."`, `removed: {}`
- No write to the user record
- The flow simply continues

Referenced entities are **not** existence-checked server-side either, so a deleted feature or meditation category stays removable — otherwise it would stick to the user forever.

Guards that do apply (identical to `assignToUser`): unknown `userId` → `404`, cross-app `userId` → `401`, no field provided → `400`.

## Verified

- `nx build pieces-coasy` ✅ (fresh, `--skip-nx-cache`)
- `nx lint pieces-coasy` — `remove-from-user.ts` is clean.

  Heads-up: lint reports **2 pre-existing prettier errors** in files I did not touch — `add-trial-period.ts:41` (came in with #7) and `send-push-notification.ts:50`. Left alone, but they will keep failing `nx lint pieces-coasy` until someone runs `--fix`.
- Server side: 12 unit tests plus a full HTTP-path run (validation → handler → response) in coasy-core PR #452.

## Also

- `@coasy/piece-coasy` → `0.2.6` (remote was already at `0.2.5`).
- Recorded the action and its gotchas in the piece's `CLAUDE.md`, including that `courses` is **not** a valid field here — the server rejects unknown body fields, and courses go through `enrollUserCourse`.

## Deploy note

The self-hosted instance only sees `Remove From User` once `0.2.6` is published (per README: manual `npm publish` from `dist/`, since `publish-piece` has dependency-resolution issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)