### PR TITLE
feat(coasy): add sendEmail action

### DIFF
--- a/packages/pieces/community/coasy/CLAUDE.md
+++ b/packages/pieces/community/coasy/CLAUDE.md
@@ -27,6 +27,7 @@ The doc is **private** — fetch it with `gh api repos/coasy/coasy-core/contents
 | `enrollUserCourse` | `POST /apps/actions/enrollUserCourse` | Enroll a user in a course |
 | `findEvent` | `POST /apps/actions/findEvent` | Find events of the calling app by exact title |
 | `removeFromUser` | `POST /apps/actions/removeFromUser` | Remove features / community topics / topic groups / meditation categories from a user |
+| `sendEmail` | `POST /apps/actions/sendEmail` | Queue an email dispatch to a raw email address |
 | `sendPushNotification` | `POST /apps/actions/sendPushNotification` | Send a push notification to all of a user's devices |
 
 ### Gotchas worth remembering
@@ -36,6 +37,8 @@ The doc is **private** — fetch it with `gh api repos/coasy/coasy-core/contents
 - **`sendPushNotification`** accepts a `topic` field in the DTO but it is silently discarded by the current `buildNotification` implementation — do not expose it as a piece property until the upstream handler is fixed.
 - **`createFunnelParticipant`** lowercases `email` server-side. The response includes server-generated `funnelParticipantId`, `registrationTime`, and `timestamp`.
 - **`createVoucher`** auto-generates the voucher ID (`VOC-…`) and sets `status: "ACTIVE"`. Setting `countLeft` implicitly sets `isCountLimited: true`.
+- **`sendEmail`** requires exactly one of `templateKey` / `templateId` (XOR, `400` otherwise). A `templateId` of a foreign app returns `401`, an unknown or soft-deleted one `404`. `data` is validated against the `MetaData` DTO — unknown keys are rejected with `400`.
+- **`POST /apps/actions/listEmailTemplates`** is a backend endpoint the piece calls, not a piece action — it only backs the Send Email template dropdown, via `common/emailTemplates.ts`. It takes no body and returns only the app's *configured* keys, not the whole `email_templates` table. Keys whose template is gone are omitted. Several keys can share one template.
 - **`addTrialPeriod`** has its own domain error model (`AppSubscriptionError`) mapped to HTTP via `toApiErrorIfAppSubscriptionError` — surface the server's error message rather than masking it.
 - **`addTrialPeriod` funnel guard** (coasy-core PR #220): the piece's `funnelGuard` array maps to the nested body `guards: { funnel: string[] }`. Guards are checked before the user is resolved; a match is a **silent no-op success** (`subscriptionStatus: "BLOCKED"`, `blockedBy` set, HTTP 200) — nothing is created/extended. Omitting it preserves original behavior.
 

--- a/packages/pieces/community/coasy/README.md
+++ b/packages/pieces/community/coasy/README.md
@@ -140,11 +140,11 @@ The piece uses custom authentication with:
 
 ## Publishing
 
-The piece is published as `@coasy/piece-coasy` to npm. Version is currently `0.0.13`.
+The piece is published as `@coasy/piece-coasy` to npm. Version is currently `0.3.0`.
 
 To publish a new version:
 
-1. Update the `version` in `package.json` in Coasy community folder (e.g., from `0.0.13` to `0.0.14`)
+1. Update the `version` in `package.json` in Coasy community folder (e.g., from `0.3.0` to `0.3.1`)
 2. Build the package with:
    ```bash
    npm run build-piece coasy

--- a/packages/pieces/community/coasy/package.json
+++ b/packages/pieces/community/coasy/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@coasy/piece-coasy",
-  "version": "0.2.6"
+  "version": "0.3.0"
 }

--- a/packages/pieces/community/coasy/src/index.ts
+++ b/packages/pieces/community/coasy/src/index.ts
@@ -8,6 +8,7 @@ import { createFunnelParticipant } from './lib/actions/create-funnel-participant
 import { createVoucher } from './lib/actions/create-voucher';
 import { enrollUserCourse } from './lib/actions/enroll-user-course';
 import { findEvent } from './lib/actions/find-event';
+import { sendEmail } from './lib/actions/send-email';
 import { sendPushNotification } from './lib/actions/send-push-notification';
 import { cancelledMembership } from './lib/triggers/cancelled-membership';
 import { cancelledOrder } from './lib/triggers/cancelled-order';
@@ -62,6 +63,7 @@ export const coasy = createPiece({
     enrollUserCourse,
     findEvent,
     removeFromUser,
+    sendEmail,
     sendPushNotification,
   ],
   triggers: [

--- a/packages/pieces/community/coasy/src/lib/actions/send-email.ts
+++ b/packages/pieces/community/coasy/src/lib/actions/send-email.ts
@@ -1,0 +1,66 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { coasyAuth } from '../../index';
+import { runCoasyAction } from '../common/actions';
+import { emailTemplateId, emailTemplateKey } from '../common/emailTemplates';
+
+const name = 'sendEmail';
+
+export const sendEmail = createAction({
+  auth: coasyAuth,
+  name,
+  displayName: 'Send Email',
+  description: 'Queues an email dispatch to a raw email address',
+  props: {
+    toEmail: Property.ShortText({
+      displayName: 'To Email',
+      description: 'Recipient email address',
+      required: true,
+    }),
+    toName: Property.ShortText({
+      displayName: 'To Name',
+      description: 'Optional recipient name',
+      required: false,
+    }),
+    templateKey: emailTemplateKey,
+    templateId: emailTemplateId,
+    bcc: Property.Array({
+      displayName: 'BCC',
+      description: 'Optional blind copy recipients',
+      required: false,
+    }),
+    data: Property.Object({
+      displayName: 'Template Variables',
+      description:
+        'Optional template variables. Only keys known to the Coasy MetaData DTO are accepted, e.g. firstName, lastName, link, voucherCode — unknown keys are rejected with a 400.',
+      required: false,
+    }),
+    attachments: Property.Array({
+      displayName: 'Attachments',
+      required: false,
+      properties: {
+        filename: Property.ShortText({
+          displayName: 'Filename',
+          required: true,
+        }),
+        contentType: Property.ShortText({
+          displayName: 'Content Type',
+          description: 'MIME type, e.g. application/pdf',
+          required: true,
+        }),
+        base64Content: Property.LongText({
+          displayName: 'Base64 Content',
+          required: true,
+        }),
+      },
+    }),
+  },
+  // templateKey / templateId are XOR — both optional here, the server rejects both-or-neither.
+  run: (configValue) => {
+    const { bcc, ...rest } = configValue.propsValue;
+    // An untouched BCC array arrives as [], which the server treats as "set" and
+    // then skips adding the archive address to the dispatch — omit it instead.
+    const request = Array.isArray(bcc) && bcc.length > 0 ? { ...rest, bcc } : rest;
+
+    return runCoasyAction(configValue, name, request);
+  },
+});

--- a/packages/pieces/community/coasy/src/lib/common/actions.ts
+++ b/packages/pieces/community/coasy/src/lib/common/actions.ts
@@ -3,7 +3,7 @@ import {
   InputPropertyMap,
 } from '@activepieces/pieces-framework';
 import { coasyAuth } from '../..';
-import { CoasyClient } from './coasyClient';
+import { createCoasyClient } from './coasyClient';
 
 export const runCoasyAction = async <T extends InputPropertyMap>(
   configValue: ActionContext<typeof coasyAuth, T>,
@@ -11,10 +11,7 @@ export const runCoasyAction = async <T extends InputPropertyMap>(
   request?: Record<string, unknown>
 ) => {
   const { propsValue, auth: authPayload } = configValue;
-  const client = new CoasyClient(
-    authPayload.baseUrl ?? 'https://backend.api.prod.coasy.io',
-    authPayload.apiKey
-  );
+  const client = createCoasyClient(authPayload);
 
   const body = { ...(request ?? propsValue) };
   delete body['auth'];

--- a/packages/pieces/community/coasy/src/lib/common/coasyClient.ts
+++ b/packages/pieces/community/coasy/src/lib/common/coasyClient.ts
@@ -5,6 +5,13 @@ import {
   HttpRequest,
 } from '@activepieces/pieces-common';
 
+export type CoasyAuth = {
+  baseUrl?: string;
+  apiKey: string;
+};
+
+export const DEFAULT_BASE_URL = 'https://backend.api.prod.coasy.io';
+
 export class CoasyClient {
   private baseUrl: string;
   private apiKey: string;
@@ -56,3 +63,6 @@ export class CoasyClient {
     }
   }
 }
+
+export const createCoasyClient = (auth: CoasyAuth) =>
+  new CoasyClient(auth.baseUrl ?? DEFAULT_BASE_URL, auth.apiKey);

--- a/packages/pieces/community/coasy/src/lib/common/emailTemplates.ts
+++ b/packages/pieces/community/coasy/src/lib/common/emailTemplates.ts
@@ -1,0 +1,65 @@
+import { Property } from '@activepieces/pieces-framework';
+import { CoasyAuth, createCoasyClient } from './coasyClient';
+
+export interface EmailTemplate {
+  templateKey: string;
+  emailTemplateId: string;
+  name: string;
+  subject: string;
+  language?: string;
+}
+
+export const fetchEmailTemplates = async (
+  auth: CoasyAuth
+): Promise<EmailTemplate[]> => {
+  const response = (await createCoasyClient(auth).action(
+    'listEmailTemplates',
+    {}
+  )) as { templates?: EmailTemplate[] };
+
+  return response.templates ?? [];
+};
+
+const templateLabel = (template: EmailTemplate) =>
+  template.language ? `${template.name} (${template.language})` : template.name;
+
+export const emailTemplateKey = Property.Dropdown({
+  displayName: 'Email Template',
+  description:
+    'Template configured for this app under a template key. Set either this or the Template ID, not both.',
+  required: false,
+  refreshers: ['auth'],
+  options: async ({ auth }) => {
+    if (!auth) {
+      return {
+        disabled: true,
+        placeholder: 'Connect your account',
+        options: [],
+      };
+    }
+
+    const templates = await fetchEmailTemplates(auth as CoasyAuth);
+
+    if (templates.length === 0) {
+      return {
+        disabled: true,
+        placeholder: 'This app has no email templates configured',
+        options: [],
+      };
+    }
+
+    return {
+      options: templates.map((template) => ({
+        label: templateLabel(template),
+        value: template.templateKey,
+      })),
+    };
+  },
+});
+
+export const emailTemplateId = Property.ShortText({
+  displayName: 'Template ID',
+  description:
+    'ID of an email template of this app, e.g. EMT-A7O-ODB-PL7. Any template of the app works, also funnel and broadcast templates that are not bound to a template key. Set either this or the Email Template, not both.',
+  required: false,
+});


### PR DESCRIPTION
## What

Adds a **Send Email** action to the Coasy piece, backed by `POST /apps/actions/sendEmail`.

- `sendEmail` action: `toEmail`, `toName`, `templateKey` / `templateId` (XOR — the server rejects both-or-neither), `bcc`, `data`, `attachments`
- `common/emailTemplates.ts`: the template dropdown, populated from the `listEmailTemplates` backend action, plus the free-text Template ID property
- `coasyClient.ts`: extracted `CoasyAuth`, `DEFAULT_BASE_URL` and `createCoasyClient` so the dropdown can build a client straight from the auth payload; `runCoasyAction` now uses the factory
- piece bumped to `0.3.0`, README publish version refreshed, CLAUDE.md gotchas updated

## Empty BCC fix

An untouched `Property.Array` is defaulted to `[]` by the builder (`form-utils.tsx:123`), and nothing strips it downstream. The server's `if (request.bcc !== undefined)` guard passes it through, and `SendEmailTask`'s `emailDispatch.bcc ??= [archiveEmail]` does not fire on a non-nullish `[]` — so every transactional send through this action would silently lose its archive BCC. The action now omits `bcc` unless it actually has entries.

## Testing

- `nx build pieces-coasy --skip-nx-cache` green
- Send Email exercised end-to-end from the Activepieces test step against the Coasy backend

## Known follow-ups (not in this PR)

- `SendEmailTask.ts:203` should treat an empty `bcc` array as absent, so other callers cannot hit the same hole
- template dropdown throws `Failed to communicate with Mailjet` (a pre-existing, misnamed error in `CoasyClient.request`) instead of showing a disabled placeholder when `listEmailTemplates` returns non-200
- dropdown keys come from stored config while the server validates against `getPropertyKeys(AppEmailTemplates)`; a key present in one and not the other is only rejected at run time
- multiple primary recipients would need a backend change — `toEmail` is a single `@IsEmail()` string

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coasy/codesmith/activepieces/pr/9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788959599&installation_model_id=430620&pr_number=9&repository=coasy%2Factivepieces&return_to=https%3A%2F%2Fgithub.com%2Fcoasy%2Factivepieces%2Fpull%2F9&signature=46e78bccb3e834b8be07fb4f6737742a087c3db71cb365f492d24214c6ff4082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->